### PR TITLE
Add GitHub Action to `npx install mini-coi .`

### DIFF
--- a/.github/workflows/npx_install_mini-coi.yml
+++ b/.github/workflows/npx_install_mini-coi.yml
@@ -1,0 +1,15 @@
+name: npx_install_mini-coi
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  npx_install_mini-coi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx install mini-coi .


### PR DESCRIPTION
When I try to `npx install mini-coi .` in a GitHub Action, the command never completes.
* https://github.com/software-games/python-games/actions/workflows/static.yml