### PR TITLE
Support 204 responses

### DIFF
--- a/mini-coi.js
+++ b/mini-coi.js
@@ -21,7 +21,7 @@
         h.set('Cross-Origin-Opener-Policy', 'same-origin');
         h.set('Cross-Origin-Embedder-Policy', 'require-corp');
         h.set('Cross-Origin-Resource-Policy', 'cross-origin');
-        return new Response(body, { status, statusText, headers: h });
+        return new Response(status == 204 ? null : body, { status, statusText, headers: h });
       }));
     });
   }


### PR DESCRIPTION
This change makes mini-coi support 204 responses; when a response is 204, it just returns a blank document (null) since otherwise we aren't "allowed" to get the response body.

Associated issue is https://github.com/WebReflection/mini-coi/issues/7